### PR TITLE
Fixing issue #3 and #4 on GitHub.

### DIFF
--- a/stream.lisp
+++ b/stream.lisp
@@ -109,14 +109,16 @@ stream."
   (declare #.*standard-optimize-settings*)
   (with-accessors ((stream flexi-stream-stream))
       stream
-    (stream-file-position stream)))
+    (file-position stream)))
 
 (defmethod (setf stream-file-position) (position-spec (stream flexi-stream))
   "Dispatch to method for underlying stream."
   (declare #.*standard-optimize-settings*)
-  (with-accessors ((stream flexi-stream-stream))
+  (with-accessors ((underlying-stream flexi-stream-stream))
       stream
-    (setf (stream-file-position stream) position-spec)))
+    (if (file-position underlying-stream position-spec)
+        (setf (flexi-stream-position stream) (file-position underlying-stream))
+          nil)))
 
 (defclass flexi-output-stream (flexi-stream fundamental-binary-output-stream
                                             fundamental-character-output-stream)


### PR DESCRIPTION
Issue #3: calling FILE-POSITION instead of STREAM-FILE-POSITION, per
trivial-gray-streams maintainer request.

Issue #4: flexi-streams was not updating its notion of POSITION.
Wanted to be defer handling of :start/:end to underlying stream,
so the setter method of STREAM-FILE-POSITION calls FILE-POSITION
(aka Issue #3), then if that returns a non-nil value, calls
FILE-POSITION to find what POSITION should be set to.
