### PR TITLE
Support strings as external-format name specifiers

### DIFF
--- a/external-format.lisp
+++ b/external-format.lisp
@@ -320,7 +320,7 @@ of a Windows code page \(and ignored for other encodings)."
   (declare #.*standard-optimize-settings*)
   ;; the keyword arguments are only there for arglist display in the IDE
   (declare (ignore id little-endian))
-  (let ((shortcut-args (cdr (assoc name +shortcut-map+))))
+  (let ((shortcut-args (cdr (assoc name +shortcut-map+ :test #'string-equal))))
     (cond (shortcut-args
            (apply #'make-external-format%
                   (append shortcut-args

--- a/test/packages.lisp
+++ b/test/packages.lisp
@@ -35,5 +35,7 @@
                 :with-unique-names
                 :with-rebinding
                 :char*
-                :normalize-external-format)
+                :normalize-external-format
+                :+name-map+
+                :+shortcut-map+)
   (:export :run-all-tests))

--- a/util.lisp
+++ b/util.lisp
@@ -109,12 +109,11 @@ are discarded \(that is, the body is an implicit PROGN)."
 external format, e.g. :LATIN1 will be converted to :ISO-8859-1.
 Also checks if there is an external format with that name and
 signals an error otherwise."
-  (let ((real-name (or (cdr (assoc name +name-map+
-                                   :test #'eq))
-                       name)))
-    (unless (find real-name +name-map+
-                  :test #'eq
-                  :key #'cdr)
+  (let ((real-name (cdr (find name flex::+name-map+
+                              :test (lambda (item pair)
+                                      (or (string-equal item (cdr pair))
+                                          (string-equal item (car pair))))))))
+    (unless real-name
       (error 'external-format-error
              :format-control "~S is not known to be a name for an external format."
              :format-arguments (list name)))


### PR DESCRIPTION
Code change focuses on use of string-equal to find an external-format
from the name argument to make-external-format.

A test is included which iterates over +name-map+ and +shortcut-map+.

Maybe the test is a little overboard. Happy to refactor as you like.