### PR TITLE
Fix handling of end-of-file in `peek-byte`.

### DIFF
--- a/input.lisp
+++ b/input.lisp
@@ -283,12 +283,15 @@ not 0 is returned, if PEEK-TYPE is an octet, the next octet which
 equals PEEK-TYPE is returned.  EOF-ERROR-P and EOF-VALUE are
 interpreted as usual."
   (declare #.*standard-optimize-settings*)
-  (loop for octet = (read-byte flexi-input-stream eof-error-p eof-value)
+  (loop for octet = (read-byte flexi-input-stream eof-error-p :eof)
         until (cond ((null peek-type))
-                    ((eql octet eof-value))
+                    ((eql octet :eof))
                     ((eq peek-type t)
                      (plusp octet))
                     (t (= octet peek-type)))
-        finally (unless (eql octet eof-value)
-                  (unread-byte octet flexi-input-stream))
-                (return octet)))
+        finally (cond
+                  ((eql octet :eof)
+                   (return eof-value))
+                  (t
+                   (unread-byte octet flexi-input-stream)
+                   (return octet)))))


### PR DESCRIPTION
`peek-byte` doesn't handle `eof-value` correctly when `eof-error-p` is
false and `eof-value` is a byte that occurs in the stream. For instance,

    (with-input-from-sequence (input #(0 1 2))
      (let ((stream (make-flexi-stream input)))
        (peek-byte stream 2 nil 1)))

returns `1`, when it should return `2`.

Additionally, in the above case, the last byte that was read is not
unread, although it should be:

    (with-input-from-sequence (input #(0 1 2))
      (let ((stream (make-flexi-stream input)))
        (peek-byte stream 2 nil 1)
        (peek-byte stream nil nil nil)))

returns `nil`.