### PR TITLE
add sane stream-element-type for in-memory streams.

### DIFF
--- a/in-memory.lisp
+++ b/in-memory.lisp
@@ -126,10 +126,14 @@ associated vector."))
     (error 'in-memory-stream-closed-error
            :stream stream)))
 
-(defmethod stream-element-type ((stream in-memory-stream))
-  "The element type is always OCTET by definition."
-  (declare #.*standard-optimize-settings*)
-  'octet)
+(defmethod stream-element-type ((stream vector-input-stream))
+  "This returns actual array type of the underlying vector."
+  (array-element-type (vector-stream-vector stream)))
+
+(defmethod stream-element-type ((stream list-input-stream))
+  "This returns 't. Lists do not have element type."
+  't)
+
 
 (defmethod transform-octet ((stream in-memory-stream) octet)
   "Applies the transformer of STREAM to octet and returns the result."


### PR DESCRIPTION
stream-element-type does not behave consistent with in-memory streams. Consider the following.

```
(let ((fs (make-in-memory-input-stream #(300 300 300))))
        (stream-element-type fs))
--> 'OCTET

(let ((fs (make-in-memory-input-stream #(300 300 300))))
        (read-byte fs))
--> 300
```


As 300 does not form an octet my opinion is that stream-element-type should return the proper element type of the underlying vector or list. The new behaviour would be:

```
(let ((fs (make-in-memory-input-stream #(300 300 300))))
        (stream-element-type fs))
--> 't ;; same for lists.

(let ((fs (make-in-memory-input-stream (make-array 3 :element-type '(unsigned-byte 8)))
        (stream-element-type fs))
--> '(unsigned-byte 8)

```

Is there a reason for the current behaviour that I am not seeing?
I have proposed a patch if the new behaviour satisfactory. All tests are 100%. 


