### PR TITLE
Ensure elements of in-memory-input-stream is always of type octet.

### DIFF
--- a/in-memory.lisp
+++ b/in-memory.lisp
@@ -304,7 +304,7 @@ Each octet returned will be transformed in turn by the optional
 TRANSFORMER function."
   (declare #.*standard-optimize-settings*)
   (make-instance 'vector-input-stream
-                 :vector vector
+                 :vector (coerce vector '(vector octet))
                  :index start
                  :end end
                  :transformer transformer))
@@ -318,7 +318,10 @@ octet returned will be transformed in turn by the optional
 TRANSFORMER function."
   (declare #.*standard-optimize-settings*)
   (make-instance 'list-input-stream
-                 :list (subseq list start end)
+                 :list (loop for elt in (nthcdr start list)
+                             repeat (- end start)
+                             do (check-type elt octet)
+                             collect elt)
                  :transformer transformer))
 
 (defun make-output-vector (&key (element-type 'octet))


### PR DESCRIPTION
This is an alternative to pull request: add sane stream-element-type for in-memory streams. #19

The elements of an in-memory-stream is expected to always be of type octet. Anything else can lead to corrupted output. Example:

```common-lisp
(read-char (flex:make-flexi-stream (flex:make-in-memory-input-stream #(-10))))
==> #\UFFFFF6
```
