### PR TITLE
Add safety 0 for SBCL

### DIFF
--- a/specials.lisp
+++ b/specials.lisp
@@ -32,6 +32,7 @@
 (defvar *standard-optimize-settings*
   '(optimize
     speed
+    #+sbcl (safety 0)
     (space 0)
     (debug 1)
     (compilation-speed 0))
@@ -40,6 +41,7 @@
 (defvar *fixnum-optimize-settings*
   '(optimize
     speed
+    #+sbcl (safety 0)
     (space 0)
     (debug 1)
     (compilation-speed 0)


### PR DESCRIPTION
flexi-streams gives an error the nil is not of type  (MOD 1114112).
This is true...